### PR TITLE
Hotfix 유저승무패 갱신문제

### DIFF
--- a/src/components/User/UserInfoDisplay.tsx
+++ b/src/components/User/UserInfoDisplay.tsx
@@ -1,13 +1,20 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { MdChangeCircle } from 'react-icons/md';
 import useCurrentUser from '../../hooks/auth/useCurrentUser';
 import useUpdateProfileImage from '../../hooks/auth/useUpdateProfileImage';
+import useLogin from '../../hooks/auth/useLogin';
 
 const UserInfoDisplay = () => {
   const {
     user: { nickname, profileImgUrl, win, lose, draw, id },
   } = useCurrentUser();
+
+  const { fetchUserInfo } = useLogin();
+  useEffect(() => {
+    fetchUserInfo();
+  }, []);
+
   const { handleUpdateUserImage } = useUpdateProfileImage();
   const imageRef = useRef<HTMLInputElement>(null);
   const handleClickImage = () => {

--- a/src/hooks/socket/useStomp.ts
+++ b/src/hooks/socket/useStomp.ts
@@ -1,5 +1,5 @@
 import { CompatClient, Stomp, StompSubscription } from '@stomp/stompjs';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import SockJS from 'sockjs-client';
 
 interface ObjectType {
@@ -8,9 +8,10 @@ interface ObjectType {
 
 let socketClient: WebSocket;
 let stompClient: CompatClient;
-const subscriptions: { [key: string]: StompSubscription } = {};
 let isConnected = false;
-export function useStomp(url: string, callback?: any) {
+const subscriptions: { [key: string]: StompSubscription } = {};
+
+export function useStomp(url: string, callback?: () => void) {
   const connect = useCallback(() => {
     if (!socketClient) {
       socketClient = new SockJS(url);

--- a/src/lagacy/useNotificationSocket.ts
+++ b/src/lagacy/useNotificationSocket.ts
@@ -11,7 +11,6 @@ export function useNotificationSocket(userId: number | string | undefined, callb
   const socketRef = useRef<WebSocket | null>(null);
   const stompClientRef = useRef<CompatClient | null>(null);
   const subscriptionRef = useRef<StompSubscription | null | undefined>(null);
-  const accessToken = window.localStorage.getItem('accessToken');
   const dispatch = useDispatch();
   const { isLogin } = useSelector((state: RootState) => state.user);
   const notifications = useSelector((state: RootState) => state.notification.notifications);


### PR DESCRIPTION
- user정보를 승무패가 결정되고나서 갱신해주어야하는데, 자신의 경기가 아닌경우 수동적으로 변경된다 그럼으로 프로필 페이지에는 유저정보를 매번 불러와야한다.